### PR TITLE
Resolving mistake in directory listing for meta screen

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,13 +20,13 @@
     <meta name="twitter:title" content="The Top 120 CryptoCurrencies | CryptoReact">
     <meta name="twitter:description" content="A real-time dashboard that displays the top 120 cryptocurrencies based on currency price, market captilization and overall circulating supply.">
     <meta name="twitter:creator" content="@xunga">
-    <meta name="twitter:image" content="https://xunga.github.io/CryptoReact-/meta_landing_screen.png">
+    <meta name="twitter:image" content="https://xunga.github.io/CryptoReact-/img/meta_landing_screen.png">
     <meta name="twitter:image:alt" content="CryptoReact">
 
     <!-- Schema.org markup for Google+ -->
     <meta itemprop="name" content="The Top 120 CryptoCurrencies | CryptoReact">
     <meta itemprop="description" content="A real-time dashboard that displays the top 120 cryptocurrencies based on currency price, market captilization and overall circulating supply.">
-    <meta itemprop="image" content="https://xunga.github.io/CryptoReact-/meta_landing_screen.png">
+    <meta itemprop="image" content="https://xunga.github.io/CryptoReact-/img/meta_landing_screen.png">
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.


### PR DESCRIPTION
My apologies man! Mistakenly redirected to the wrong path for the meta_landing_screen with regards to the twitter/google plus tags.

This should be good. Sorry again man!